### PR TITLE
Update netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [template.environment]
-  NEWS_API_KEY = "<include your API key from news-api.org here>"
+  NEWS_API_KEY = "<include your API key from newsapi.org here>"


### PR DESCRIPTION
news-api.org works but the actual website is newsapi.org.